### PR TITLE
Removed the MYSQL_USER=root env

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,7 +28,6 @@ services:
     environment: 
       - MYSQL_DATABASE=nodedb
       - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=root
     networks: 
       - node-network
 


### PR DESCRIPTION
A variável `MYSQL_USER=root` foi removida nas ultimas atualizações e está gerando um erro na hora de subir o banco